### PR TITLE
Partition Equal Subset Sum

### DIFF
--- a/Partition Equal Subset Sum.cpp
+++ b/Partition Equal Subset Sum.cpp
@@ -1,0 +1,33 @@
+class Solution {
+public:
+    bool subsetSum(vector<int>& nums, int sum){
+        int n = nums.size();
+        int t[n+1][sum+1];
+        for(int i = 0; i < n+1; i++){
+            for(int j = 0; j < sum+1; j++){
+                if(i == 0)
+                    t[i][j] = false;
+                if(j == 0)
+                    t[i][j] = true;
+            }
+        }
+        for(int i = 1; i < n+1; i++){
+            for(int j = 1; j < sum+1; j++){
+                t[i][j] = t[i-1][j];
+                if(nums[i-1] <= j)
+                    t[i][j] |= t[i-1][j-nums[i-1]];
+            }
+        }
+        return t[n][sum];
+    }
+    bool canPartition(vector<int>& nums) {
+        int n = nums.size();
+        long sum = 0;
+        for(int i = 0; i < n; i++)
+            sum = sum + nums[i];
+        if(sum % 2 != 0)
+            return false;
+            
+        return subsetSum(nums, sum/2);
+    }
+};


### PR DESCRIPTION
Given a non-empty array nums containing only positive integers, find if the array can be partitioned into two subsets such that the sum of elements in both subsets is equal.

Example :

Input: nums = [1,5,11,5]
Output: true
Explanation: The array can be partitioned as [1, 5, 5] and [11].

Constraints:

1 <= nums.length <= 200
1 <= nums[i] <= 100